### PR TITLE
Add OpenAI command to web CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ You can install `vercel` cli and follow the instruction [here](https://vercel.co
 
 You can also connect your github account to vercel and have vercel automatically deploy the github repository for you.
 
+## Using the `openai` command
+
+You can now use the `openai` command to interact with the Azure OpenAI service. Simply type `openai <prompt>` in the command line interface to get responses from the Azure OpenAI service.
+
 ## Credit
 
 Based on M4TT72's awesome [Terminal](https://github.com/m4tt72/terminal).

--- a/config.json
+++ b/config.json
@@ -35,5 +35,7 @@
       "blue": "#EBCB8B",
       "red": "#BF616A"
     }
-  }
+  },
+  "openAiApiKey": "c4732d21e0c743b5a657c9cfb1015d2b",
+  "openAiEndpoint": "https://ai-senuk.openai.azure.com/"
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -28,3 +28,24 @@ export const getQuote = async () => {
     quote: `“${data.content}” — ${data.author}`,
   };
 };
+
+export const getOpenAiResponse = async (prompt: string) => {
+  try {
+    const { data } = await axios.post(
+      `${config.openAiEndpoint}/openai/deployments/${config.deploymentName}/completions?api-version=2022-12-01`,
+      {
+        prompt,
+        max_tokens: 100,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'api-key': config.openAiApiKey,
+        },
+      }
+    );
+    return data.choices[0].text.trim();
+  } catch (error) {
+    return `Error: ${error.response ? error.response.data.error.message : error.message}`;
+  }
+};

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as bin from './bin';
+import { getOpenAiResponse } from './api';
 
 export const shell = async (
   command: string,
@@ -14,6 +15,10 @@ export const shell = async (
     clearHistory();
   } else if (command === '') {
     setHistory('');
+  } else if (args[0] === 'openai') {
+    const prompt = args.slice(1).join(' ');
+    const response = await getOpenAiResponse(prompt);
+    setHistory(response);
   } else if (Object.keys(bin).indexOf(args[0]) === -1) {
     setHistory(
       `shell: command not found: ${args[0]}. Try 'help' to get started.`,


### PR DESCRIPTION
Implement Azure OpenAI service integration into the web command line interface.

* **config.json**
  - Add `openAiApiKey` and `openAiEndpoint` to store the Azure OpenAI API key and endpoint URL.

* **src/utils/api.ts**
  - Add a new function `getOpenAiResponse` to fetch responses from Azure OpenAI service.

* **src/utils/shell.ts**
  - Add a new command `openai` to handle user prompts and fetch responses from Azure OpenAI service.

* **README.md**
  - Add instructions on how to use the new `openai` command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SenukDias/Dev_Portfolio_v.1/pull/30?shareId=4328f7f0-955b-4f76-9552-9fdc40bfc184).